### PR TITLE
perf: fix N+1 query issue in Products Index component

### DIFF
--- a/app/Livewire/Products/Index.php
+++ b/app/Livewire/Products/Index.php
@@ -161,7 +161,7 @@ class Index extends Component
         $query = Product::query()
             ->with([
                 'warehouses',
-                'category',
+                'category' => fn ($q) => $q->withCount('products'),
                 'brand',
                 'movements',
             ])

--- a/resources/views/livewire/products/index.blade.php
+++ b/resources/views/livewire/products/index.blade.php
@@ -186,7 +186,7 @@
                                         <div class="font-medium">{{ $product->category->name }}</div>
                                         <div
                                             class="text-xs text-orange-600 dark:text-orange-500 group-hover:text-orange-700 dark:group-hover:text-orange-400">
-                                            ({{ $product->ProductsByCategory($product->category->id) }})
+                                            ({{ $product->category->products_count ?? 0 }})
                                             {{ __('products') }}
                                         </div>
                                     </div>


### PR DESCRIPTION
Eliminates an N+1 query issue in the `App\Livewire\Products\Index` component by eagerly loading the `products_count` on the `category` relation instead of executing a fresh query (`ProductsByCategory()`) for every product on the page.

Symptom:
Rendering the products index triggered a separate `select count(*) from products where category_id = ?` query for each product in the view.

Mechanism:
Changed the `$query->with(['category' => fn($q) => $q->withCount('products')])` in the component and replaced `$product->ProductsByCategory(...)` in the Blade view with the eager-loaded `$product->category->products_count ?? 0`. This safely bounds the query count.